### PR TITLE
fix TOML string

### DIFF
--- a/tool.py
+++ b/tool.py
@@ -15,7 +15,7 @@ def init(url):
     title = "OLI BOX Config"
 
     [web3_provider]
-    url = {url}
+    url = "{url}"
 
     """
     parsed_config = toml.loads(config)


### PR DESCRIPTION
This fixes the issue `ValueError: This float doesn't have a leading digit` by properly enclosing the URL string in quotes, [as required by the TOML standard](https://github.com/toml-lang/toml#string).

Given the input `https://example.com/` the script then produces this output:

```toml
title = "OLI BOX Config"

[web3_provider]
url = "https://example.com/"
```